### PR TITLE
Better handling of finding the category

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,11 @@ const main = async () => {
   const categoryName = core.getInput("category") || "General"
   const category = repository.discussionCategories.nodes.find(c => c.name === categoryName)
 
+  if (category === undefined) {
+    core.setFailed(`Could not find category ${categoryName}`)
+    return
+  }
+
   await createDiscussion(authToken, finalDiscussionBody, discussionTitle, repository.id, category.id)
 }
 
@@ -28,7 +33,7 @@ const getRepositoryData = async (authToken) => {
       query repositoryId($owner: String!, $name: String!) {
         repository(owner: $owner, name: $name) {
           id
-          discussionCategories(first: 10) {
+          discussionCategories(first: 100) {
             nodes {
               id
               name


### PR DESCRIPTION
This PR includes two changes:

1. Update the GraphQL call to return the first 100 categories for those repos with greater than 10 categories
2. Output a descriptive error message if the category is not found. Currently, it outputs a vague `cannot get id of undefined` error.

We ran into the issue when attempting to use the action on a repo where the category we wanted was the 11th category and it took some time to debug the vague error. cc @pro-van-chur

I wasn't sure how to build the `dist` version of the code, so I didn't include it in the PR.
